### PR TITLE
bug: Fixing url resolution to behave properly for base address that includes relative part.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run lint:staged

--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,4 @@ package-lock.json
 tsconfig.json
 prettier.config.js
 .github
-.husky
 .eslintrc.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,20 @@
 MIT License
 
-Copyright (c) 2022 Mike Hall
+Copyright (c) 2023 Mike Hall, Jakub Leśniak
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# nestjs-fetch
+# nestjs-fetch-module
 
 A lightweight NestJS wrapper around the native `fetch()` API.
 
 The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) is
 awesome, but until recently we have needed a library to use it with Node. As of
-Node 18, Fetch is available by default (based on the `undici` library). Hurrah!
-This library wraps a small API around native `fetch()` so it can be used in
-NestJS instead of `@nestjs/axios`.
+Node 18, Fetch is available by default (based on the `undici` library). This
+library wraps a small API around native `fetch()` so it can be used in NestJS
+instead of `@nestjs/axios`.
 
 Note: This is not a drop-in replacement for `@nestjs/axios` or the `HttpModule`.
 It has a completely different API.
@@ -14,7 +14,7 @@ It has a completely different API.
 ## Installation
 
 ```bash
-npm install nestjs-fetch
+npm install nestjs-fetch-module
 ```
 
 ### Usage
@@ -25,7 +25,7 @@ Import the `FetchModule` in your application module.
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { FetchModule } from 'nestjs-fetch';
+import { FetchModule } from 'nestjs-fetch-module';
 
 @Module({
 	imports: [FetchModule],
@@ -39,7 +39,7 @@ The `FetchService` is now available as a provider in your application.
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { FetchService } from 'nestjs-fetch';
+import { FetchService } from 'nestjs-fetch-module';
 
 @Injectable()
 export class AppService {
@@ -87,7 +87,7 @@ Set up as a provider in your app module:
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { FetchModule } from 'nestjs-fetch';
+import { FetchModule } from 'nestjs-fetch-module';
 
 @Module({
 	imports: [FetchModule.register({ baseUrl: 'http://example.com' })],
@@ -103,7 +103,7 @@ Async set up is also supported.
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { FetchModule } from 'nestjs-fetch';
+import { FetchModule } from 'nestjs-fetch-module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({

--- a/lib/fetch.service.spec.ts
+++ b/lib/fetch.service.spec.ts
@@ -56,6 +56,20 @@ describe('FetchService', () => {
 			);
 		});
 
+		it('should resolve a relative URL when base url contains a path', async () => {
+			expect.assertions(1);
+
+			await service.get('/foo', {
+				baseUrl: 'https://example.com/api/products',
+			});
+
+			expect(fetch).toBeCalledWith(
+				expect.objectContaining({
+					url: 'https://example.com/api/products/foo',
+				}),
+			);
+		});
+
 		it('should override baseUrl with absolute URL', async () => {
 			expect.assertions(1);
 

--- a/lib/fetch.service.ts
+++ b/lib/fetch.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { FETCH_MODULE_OPTIONS } from './fetch.constants';
 import { FetchModuleOptions } from './fetch-module.interface';
+import buildFullPath from './helpers/buildFullPath';
 
 @Injectable()
 export class FetchService {
@@ -18,7 +19,7 @@ export class FetchService {
 		options: FetchModuleOptions,
 	): Request {
 		const { baseUrl, ...init } = { ...this.defaults, ...options };
-		return new Request(new URL(url, baseUrl), init);
+		return new Request(buildFullPath(baseUrl, url), init);
 	}
 
 	get(url: URL | string, options: FetchModuleOptions = {}): Promise<Response> {

--- a/lib/helpers/buildFullPath.spec.ts
+++ b/lib/helpers/buildFullPath.spec.ts
@@ -1,0 +1,23 @@
+import buildFullPath from './buildFullPath';
+
+describe('buildFullPath', () => {
+	it('should combine URLs when the requestedURL is relative', () => {
+		expect(buildFullPath('https://api.github.com', '/users')).toBe(
+			'https://api.github.com/users',
+		);
+	});
+
+	it('should return the requestedURL when it is absolute', () => {
+		expect(
+			buildFullPath('https://api.github.com', 'https://api.example.com/users'),
+		).toBe('https://api.example.com/users');
+	});
+
+	it('should not combine URLs when the baseURL is not configured', () => {
+		expect(buildFullPath(undefined, '/users')).toBe('/users');
+	});
+
+	it('should combine URLs when the baseURL and requestedURL are relative', () => {
+		expect(buildFullPath('/api', '/users')).toBe('/api/users');
+	});
+});

--- a/lib/helpers/buildFullPath.ts
+++ b/lib/helpers/buildFullPath.ts
@@ -1,0 +1,9 @@
+import combineURLs from './combineURLs';
+import isAbsoluteURL from './isAbsoluteURL';
+
+export default function buildFullPath(baseURL, requestedURL) {
+	if (baseURL && !isAbsoluteURL(requestedURL)) {
+		return combineURLs(baseURL, requestedURL);
+	}
+	return requestedURL;
+}

--- a/lib/helpers/combineURLs.spec.ts
+++ b/lib/helpers/combineURLs.spec.ts
@@ -1,0 +1,33 @@
+import combineURLs from './combineURLs';
+
+describe('combineURLs', () => {
+	it('should combine URLs', () => {
+		expect(combineURLs('https://api.github.com', '/users')).toBe(
+			'https://api.github.com/users',
+		);
+	});
+
+	it('should remove duplicate slashes', () => {
+		expect(combineURLs('https://api.github.com/', '/users')).toBe(
+			'https://api.github.com/users',
+		);
+	});
+
+	it('should insert missing slash', () => {
+		expect(combineURLs('https://api.github.com', 'users')).toBe(
+			'https://api.github.com/users',
+		);
+	});
+
+	it('should not insert slash when relative url missing/empty', () => {
+		expect(combineURLs('https://api.github.com/users', '')).toBe(
+			'https://api.github.com/users',
+		);
+	});
+
+	it('should allow a single slash for relative url', () => {
+		expect(combineURLs('https://api.github.com/users', '/')).toBe(
+			'https://api.github.com/users/',
+		);
+	});
+});

--- a/lib/helpers/combineURLs.ts
+++ b/lib/helpers/combineURLs.ts
@@ -1,0 +1,5 @@
+export default function combineURLs(baseURL, relativeURL) {
+	return relativeURL
+		? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+		: baseURL;
+}

--- a/lib/helpers/isAbsoluteURL.spec.ts
+++ b/lib/helpers/isAbsoluteURL.spec.ts
@@ -1,0 +1,23 @@
+import isAbsoluteURL from './isAbsoluteURL';
+
+describe('isAbsoluteURL', () => {
+	it('should return true if URL begins with valid scheme name', () => {
+		expect(isAbsoluteURL('https://api.github.com/users')).toBe(true);
+		expect(isAbsoluteURL('custom-scheme-v1.0://example.com/')).toBe(true);
+		expect(isAbsoluteURL('HTTP://example.com/')).toBe(true);
+	});
+
+	it('should return false if URL begins with invalid scheme name', () => {
+		expect(isAbsoluteURL('123://example.com/')).toBe(false);
+		expect(isAbsoluteURL('!valid://example.com/')).toBe(false);
+	});
+
+	it('should return true if URL is protocol-relative', () => {
+		expect(isAbsoluteURL('//example.com/')).toBe(true);
+	});
+
+	it('should return false if URL is relative', () => {
+		expect(isAbsoluteURL('/foo')).toBe(false);
+		expect(isAbsoluteURL('foo')).toBe(false);
+	});
+});

--- a/lib/helpers/isAbsoluteURL.ts
+++ b/lib/helpers/isAbsoluteURL.ts
@@ -1,0 +1,6 @@
+export default function isAbsoluteURL(url) {
+	// A URL is considered absolute if it begins with "<scheme>://" or "//" (protocol-relative URL).
+	// RFC 3986 defines scheme name as a sequence of characters beginning with a letter and followed
+	// by any combination of letters, digits, plus, period, or hyphen.
+	return /^([a-z][a-z\d+\-.]*:)?\/\//i.test(url);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nestjs-fetch-module",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@nestjs/common": "^9.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nestjs-fetch-module",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@nestjs/common": "^9.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nestjs-fetch-module",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@nestjs/common": "^9.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "nestjs-fetch",
-	"version": "0.0.4",
+	"name": "nestjs-fetch-module",
+	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "nestjs-fetch",
-			"version": "0.0.4",
+			"name": "nestjs-fetch-module",
+			"version": "0.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@nestjs/common": "^9.2.0",
@@ -18,7 +18,6 @@
 				"@typescript-eslint/parser": "^5.42.1",
 				"eslint": "^8.27.0",
 				"eslint-config-prettier": "^8.5.0",
-				"husky": "^8.0.2",
 				"jest": "^29.3.1",
 				"lint-staged": "^13.0.3",
 				"prettier": "^2.7.1",
@@ -2898,21 +2897,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
-			}
-		},
-		"node_modules/husky": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-			"integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
-			"dev": true,
-			"bin": {
-				"husky": "lib/bin.js"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/typicode"
 			}
 		},
 		"node_modules/ignore": {
@@ -7717,12 +7701,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true
-		},
-		"husky": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-			"integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
 			"dev": true
 		},
 		"ignore": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "Fetch API as a NestJS provider",
 	"author": "Mike Hall, Jakub Leśniak",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Fetch API as a NestJS provider",
 	"author": "Mike Hall, Jakub Leśniak",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "nestjs-fetch",
-	"version": "0.0.4",
+	"name": "nestjs-fetch-module",
+	"version": "0.0.1",
 	"description": "Fetch API as a NestJS provider",
-	"author": "Mike Hall",
+	"author": "Mike Hall, Jakub Leśniak",
 	"license": "MIT",
 	"url": "https://github.com/mikehall314/nestjs-fetch",
 	"keywords": [
@@ -17,7 +17,6 @@
 		"lint": "eslint lib",
 		"lint:staged": "lint-staged",
 		"build": "rimraf dist && tsc -p tsconfig.build.json",
-		"prepare": "husky install",
 		"prepublish:npm": "npm run build",
 		"publish:npm": "npm publish --access public",
 		"test": "jest",
@@ -47,7 +46,6 @@
 		"@typescript-eslint/parser": "^5.42.1",
 		"eslint": "^8.27.0",
 		"eslint-config-prettier": "^8.5.0",
-		"husky": "^8.0.2",
 		"jest": "^29.3.1",
 		"lint-staged": "^13.0.3",
 		"prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Fetch API as a NestJS provider",
 	"author": "Mike Hall, Jakub Leśniak",
 	"license": "MIT",
-	"url": "https://github.com/mikehall314/nestjs-fetch",
+	"url": "https://github.com/kubal5003/nestjs-fetch",
 	"keywords": [
 		"http",
 		"fetch",
@@ -31,7 +31,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/mikehall314/nestjs-fetch"
+		"url": "https://github.com/kubal5003/nestjs-fetch"
 	},
 	"peerDependencies": {
 		"@nestjs/common": "^8.0.0 || ^9.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nestjs-fetch-module",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "Fetch API as a NestJS provider",
 	"author": "Mike Hall, Jakub Leśniak",
 	"license": "MIT",


### PR DESCRIPTION
Problem: Currently the baseUrl resolution uses `new URL(url, base)`. This has the limitation that your base cannot have any path part, because it is going to get ignored.
Example: Trying to combine `/bar` with `https://abcdef.gh/foo` will result in request being issued to `https://abcdef.gh/bar` instead of `https://abcdef.gh/foo/bar`

The solution is to bring the resolution algorithm from Axios, which is already battle tested, small & licensing allows for reuse.